### PR TITLE
Removed old dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,3 @@ version = "0.7.0"
 
 [deps]
 Dash = "1b08a953-4be3-4667-9a23-3db579824955"
-
-[compat]
-julia = "1.2"
-Dash = "0.1.3"


### PR DESCRIPTION
Dependency of Dash = "0.1.3" resulted in downgrading Dash from its current version v1.1.2 to v0.1.3 which resulted in not having certain functions available like dcc_markdown.